### PR TITLE
Add `DateRange` ValueObject and optional overlap method for clean encapsulation

### DIFF
--- a/src/Support/DateRange.php
+++ b/src/Support/DateRange.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zap\Support;
+
+use Carbon\Carbon;
+
+final readonly class DateRange
+{
+    public function __construct(
+        private Carbon $startDate,
+        private Carbon $endDate,
+    ) {
+        if ($this->endDate->lte($this->startDate)) {
+            throw new \InvalidArgumentException('Range date cannot ends before it starts.');
+        }
+    }
+}

--- a/src/Support/DateRange.php
+++ b/src/Support/DateRange.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Zap\Support;
 
 use Carbon\Carbon;
+use InvalidArgumentException;
 
 final readonly class DateRange
 {
@@ -13,7 +14,12 @@ final readonly class DateRange
         private Carbon $endDate,
     ) {
         if ($this->endDate->lte($this->startDate)) {
-            throw new \InvalidArgumentException('Range date cannot ends before it starts.');
+            throw new InvalidArgumentException('Range date cannot ends before it starts.');
         }
+    }
+
+    public function overlapsWith(DateRange $otherRange): bool
+    {
+        return true;
     }
 }

--- a/src/Support/DateRange.php
+++ b/src/Support/DateRange.php
@@ -20,6 +20,7 @@ final readonly class DateRange
 
     public function overlapsWith(DateRange $otherRange): bool
     {
-        return true;
+        return $this->startDate->lt($otherRange->endDate)
+            && $this->endDate->gt($otherRange->startDate);
     }
 }

--- a/tests/Feature/DateRangeOverlappingTest.php
+++ b/tests/Feature/DateRangeOverlappingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Zap\Facades\Zap;
+
+describe('DateRange Overlapping', function (): void {
+    it('detects overlapping schedules via `overlapsWithDateRange`', function (): void {
+        $user = createUser();
+
+        $schedule1 = Zap::for($user)
+            ->from('2025-06-18')
+            ->addPeriod('08:00', '10:00')
+            ->save();
+
+        $schedule2 = Zap::for($user)
+            ->from('2025-06-18')
+            ->addPeriod('09:30', '11:00')
+            ->save();
+
+        expect($schedule1->overlapsWithDateRange($schedule2))->toBeTrue();
+    });
+
+    it('detects non-overlapping schedules via `overlapsWithDateRange`', function (): void {
+        $user = createUser();
+        $schedule1 = Zap::for($user)
+            ->from('2025-06-18')
+            ->addPeriod('08:00', '10:00')
+            ->save();
+
+        $schedule2 = Zap::for($user)
+            ->from('2025-06-18')
+            ->addPeriod('10:05', '11:30')
+            ->save();
+
+        expect($schedule1->overlapsWithDateRange($schedule2))->toBeFalse();
+    });
+});

--- a/tests/Unit/Support/DateRangeTest.php
+++ b/tests/Unit/Support/DateRangeTest.php
@@ -23,6 +23,16 @@ describe('DateRange', function (): void {
     });
 
     it('should detect overlap cases', function (): void {
-        todo('implement overlapsWith(DateRange $other): bool method');
+        $rangeA = new DateRange(
+            Carbon::parse('18-06-2025 12:00'),
+            Carbon::parse('18-06-2025 18:00'),
+        );
+
+        $rangeB = new DateRange(
+            Carbon::parse('18-06-2025 12:00'),
+            Carbon::parse('18-06-2025 18:00'),
+        );
+
+        expect($rangeA->overlapsWith($rangeB))->toBeTrue();
     });
 });

--- a/tests/Unit/Support/DateRangeTest.php
+++ b/tests/Unit/Support/DateRangeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Zap\Support\DateRange;
+
+describe('DateRange', function (): void {
+    it('can be instantiated with a valid start date and end date', function (): void {
+        $range = new DateRange(
+            Carbon::parse('18-06-2025 12:00'),
+            Carbon::parse('18-06-2025 18:00'),
+        );
+
+        expect($range)->toBeInstanceOf(DateRange::class);
+    });
+
+    it('throws if range ends before it starts', function (): void {
+        expect(fn () => new DateRange(
+            Carbon::parse('18-06-2025 18:00'),
+            Carbon::parse('18-06-2025 12:00'),
+        ))->toThrow(InvalidArgumentException::class, 'Range date cannot ends before it starts.');
+    });
+
+    it('should detect overlap cases', function (): void {
+        todo('implement overlapsWith(DateRange $other): bool method');
+    });
+});

--- a/tests/Unit/Support/DateRangeTest.php
+++ b/tests/Unit/Support/DateRangeTest.php
@@ -35,4 +35,32 @@ describe('DateRange', function (): void {
 
         expect($rangeA->overlapsWith($rangeB))->toBeTrue();
     });
+
+    it('returns true when ranges are strictly equal', function (): void {
+        $rangeA = new DateRange(
+            Carbon::parse('18-06-2025 12:00'),
+            Carbon::parse('18-06-2025 18:00'),
+        );
+
+        $rangeB = new DateRange(
+            Carbon::parse('18-06-2025 12:00'),
+            Carbon::parse('18-06-2025 18:00'),
+        );
+
+        expect($rangeA->overlapsWith($rangeB))->toBeTrue();
+    });
+
+    it('returns false when one range ends exactly when the other starts', function (): void {
+        $rangeA = new DateRange(
+            Carbon::parse('18-06-2025 12:00'),
+            Carbon::parse('18-06-2025 14:00'),
+        );
+
+        $rangeB = new DateRange(
+            Carbon::parse('18-06-2025 14:00'),
+            Carbon::parse('18-06-2025 16:00'),
+        );
+
+        expect($rangeA->overlapsWith($rangeB))->toBeFalse();
+    });
 });


### PR DESCRIPTION
This PR introduces a `DateRange` Value Object and a non-breaking `overlapsWithDateRange()` method on the `Schedule` model.

**Goal**: demonstrate how overlap logic can be encapsulated cleanly and reused via a dedicated VO.

### Highlights

- Existing `overlapsWith()` logic is untouched
- `DateRange` handles validation and comparison in a clean, testable, and extendable way
- Only the **first** `SchedulePeriod` is used for demonstration purposes
- Feature tests included

![image](https://github.com/user-attachments/assets/5e2423c4-95e1-43fe-9db9-327d4ef424f2)

---

If it makes sense, I’d be happy to:
- extend `DateRange` to cover more use cases
- progressively replace overlap logic in `Schedule` and `SchedulePeriod`  
- or drop this entirely if out of scope—no ego here ✌️