### PR TITLE
feat: define enum class for schedule types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ composer.lock
 .DS_Store
 Thumbs.db
 .cursor/
+.idea/

--- a/README.md
+++ b/README.md
@@ -332,7 +332,11 @@ return [
     'default_rules' => [
         'no_overlap' => [
             'enabled' => true,
-            'applies_to' => ['appointment', 'blocked'], // Granular control
+            'applies_to' => [
+                // Granular control
+                \Zap\Enums\ScheduleTypes::APPOINTMENT,
+                \Zap\Enums\ScheduleTypes::BLOCKED,
+            ], 
         ],
         'working_hours' => [
             'enabled' => false,

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ config(['zap.default_rules.working_hours.enabled' => false]);
 config(['zap.default_rules.no_overlap.enabled' => false]);
 
 // Granular overlap control - only check overlaps for specific schedule types
-config(['zap.default_rules.no_overlap.applies_to' => ['appointment']]);
+config(['zap.default_rules.no_overlap.applies_to' => [\Zap\Enums\ScheduleTypes::APPOINTMENT]]);
 
 // Allow weekend scheduling
 config(['zap.default_rules.no_weekends.enabled' => false]);

--- a/config/zap.php
+++ b/config/zap.php
@@ -13,7 +13,11 @@ return [
     'default_rules' => [
         'no_overlap' => [
             'enabled' => true,
-            'applies_to' => ['appointment', 'blocked'], // Which schedule types get this rule automatically
+            'applies_to' => [
+                // Which schedule types get this rule automatically
+                \Zap\Enums\ScheduleTypes::APPOINTMENT,
+                \Zap\Enums\ScheduleTypes::BLOCKED,
+            ],
         ],
         'working_hours' => [
             'enabled' => false,

--- a/database/migrations/2024_01_01_000003_add_schedule_type_to_schedules_table.php
+++ b/database/migrations/2024_01_01_000003_add_schedule_type_to_schedules_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Zap\Enums\ScheduleTypes;
 
 return new class extends Migration
 {
@@ -12,8 +13,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('schedules', function (Blueprint $table) {
-            $table->enum('schedule_type', ['availability', 'appointment', 'blocked', 'custom'])
-                ->default('custom')
+            $table->enum('schedule_type', ScheduleTypes::values())
+                ->default(ScheduleTypes::CUSTOM)
                 ->after('description');
 
             // Add indexes for performance

--- a/src/Builders/ScheduleBuilder.php
+++ b/src/Builders/ScheduleBuilder.php
@@ -4,6 +4,7 @@ namespace Zap\Builders;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Zap\Enums\ScheduleTypes;
 use Zap\Models\Schedule;
 use Zap\Services\ScheduleService;
 
@@ -179,7 +180,7 @@ class ScheduleBuilder
      */
     public function availability(): self
     {
-        $this->attributes['schedule_type'] = \Zap\Models\Schedule::TYPE_AVAILABILITY;
+        $this->attributes['schedule_type'] = ScheduleTypes::AVAILABILITY;
 
         return $this;
     }
@@ -189,7 +190,7 @@ class ScheduleBuilder
      */
     public function appointment(): self
     {
-        $this->attributes['schedule_type'] = \Zap\Models\Schedule::TYPE_APPOINTMENT;
+        $this->attributes['schedule_type'] = ScheduleTypes::APPOINTMENT;
 
         return $this;
     }
@@ -199,7 +200,7 @@ class ScheduleBuilder
      */
     public function blocked(): self
     {
-        $this->attributes['schedule_type'] = \Zap\Models\Schedule::TYPE_BLOCKED;
+        $this->attributes['schedule_type'] = ScheduleTypes::BLOCKED;
 
         return $this;
     }
@@ -209,7 +210,7 @@ class ScheduleBuilder
      */
     public function custom(): self
     {
-        $this->attributes['schedule_type'] = \Zap\Models\Schedule::TYPE_CUSTOM;
+        $this->attributes['schedule_type'] = ScheduleTypes::CUSTOM;
 
         return $this;
     }
@@ -219,18 +220,13 @@ class ScheduleBuilder
      */
     public function type(string $type): self
     {
-        $validTypes = [
-            \Zap\Models\Schedule::TYPE_AVAILABILITY,
-            \Zap\Models\Schedule::TYPE_APPOINTMENT,
-            \Zap\Models\Schedule::TYPE_BLOCKED,
-            \Zap\Models\Schedule::TYPE_CUSTOM,
-        ];
-
-        if (! in_array($type, $validTypes)) {
-            throw new \InvalidArgumentException("Invalid schedule type: {$type}. Valid types are: ".implode(', ', $validTypes));
+        try {
+            $scheduleType = ScheduleTypes::from($type);
+        } catch (\ValueError) {
+            throw new \InvalidArgumentException("Invalid schedule type: {$type}. Valid types are: ".implode(', ', ScheduleTypes::values()));
         }
 
-        $this->attributes['schedule_type'] = $type;
+        $this->attributes['schedule_type'] = $scheduleType;
 
         return $this;
     }
@@ -304,7 +300,7 @@ class ScheduleBuilder
 
         // Set default schedule_type if not specified
         if (! isset($this->attributes['schedule_type'])) {
-            $this->attributes['schedule_type'] = \Zap\Models\Schedule::TYPE_CUSTOM;
+            $this->attributes['schedule_type'] = ScheduleTypes::CUSTOM;
         }
 
         return [

--- a/src/Enums/ScheduleTypes.php
+++ b/src/Enums/ScheduleTypes.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Zap\Enums;
+
+enum ScheduleTypes: string
+{
+    case AVAILABILITY = 'availability';
+
+    case APPOINTMENT = 'appointment';
+
+    case BLOCKED = 'blocked';
+
+    case CUSTOM = 'custom';
+
+    /**
+     * Get all available schedule types.
+     *
+     * @return string[]
+     */
+    public static function values(): array
+    {
+        return collect(self::cases())
+            ->map(fn (ScheduleTypes $type): string => $type->value)
+            ->all();
+    }
+
+    /**
+     * Check this schedule type is of a specific availability type.
+     */
+    public function is(ScheduleTypes $type): bool
+    {
+        return $this->value === $type->value;
+    }
+
+    /**
+     * Get the types that allow overlaps.
+     */
+    public function allowsOverlaps(): bool
+    {
+        return match ($this) {
+            self::AVAILABILITY, self::CUSTOM => true,
+            default => false,
+        };
+    }
+
+    /**
+     * Get types that prevent overlaps.
+     */
+    public function preventsOverlaps(): bool
+    {
+        return match ($this) {
+            self::APPOINTMENT, self::BLOCKED => true,
+            default => false,
+        };
+    }
+}

--- a/src/Models/Concerns/HasSchedules.php
+++ b/src/Models/Concerns/HasSchedules.php
@@ -4,6 +4,7 @@ namespace Zap\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Zap\Builders\ScheduleBuilder;
+use Zap\Enums\ScheduleTypes;
 use Zap\Models\Schedule;
 use Zap\Services\ConflictDetectionService;
 
@@ -145,10 +146,9 @@ trait HasSchedules
             ->get();
 
         foreach ($schedules as $schedule) {
-            // For backward compatibility, treat null/custom schedules as blocking
-            $shouldBlock = $schedule->schedule_type === null ||
-                          $schedule->schedule_type === \Zap\Models\Schedule::TYPE_CUSTOM ||
-                          $schedule->preventsOverlaps();
+            $shouldBlock = $schedule->schedule_type === null
+                || $schedule->schedule_type->is(ScheduleTypes::CUSTOM)
+                || $schedule->preventsOverlaps();
 
             if ($shouldBlock && $this->scheduleBlocksTime($schedule, $date, $startTime, $endTime)) {
                 return false;

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Zap\Enums\ScheduleTypes;
 
 /**
  * @property int $id
@@ -15,7 +16,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property string|null $description
  * @property string $schedulable_type
  * @property int $schedulable_id
- * @property string $schedule_type
+ * @property ScheduleTypes $schedule_type
  * @property Carbon $start_date
  * @property Carbon|null $end_date
  * @property bool $is_recurring
@@ -32,17 +33,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  */
 class Schedule extends Model
 {
-    /**
-     * Schedule type constants.
-     */
-    public const TYPE_AVAILABILITY = 'availability';
-
-    public const TYPE_APPOINTMENT = 'appointment';
-
-    public const TYPE_BLOCKED = 'blocked';
-
-    public const TYPE_CUSTOM = 'custom';
-
     /**
      * The attributes that are mass assignable.
      */
@@ -65,6 +55,7 @@ class Schedule extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
+        'schedule_type' => ScheduleTypes::class,
         'start_date' => 'date',
         'end_date' => 'date',
         'is_recurring' => 'boolean',
@@ -144,7 +135,7 @@ class Schedule extends Model
      */
     public function scopeAvailability(Builder $query): void
     {
-        $query->where('schedule_type', self::TYPE_AVAILABILITY);
+        $query->where('schedule_type', ScheduleTypes::AVAILABILITY);
     }
 
     /**
@@ -152,7 +143,7 @@ class Schedule extends Model
      */
     public function scopeAppointments(Builder $query): void
     {
-        $query->where('schedule_type', self::TYPE_APPOINTMENT);
+        $query->where('schedule_type', ScheduleTypes::APPOINTMENT);
     }
 
     /**
@@ -160,7 +151,7 @@ class Schedule extends Model
      */
     public function scopeBlocked(Builder $query): void
     {
-        $query->where('schedule_type', self::TYPE_BLOCKED);
+        $query->where('schedule_type', ScheduleTypes::BLOCKED);
     }
 
     /**
@@ -248,7 +239,7 @@ class Schedule extends Model
      */
     public function isAvailability(): bool
     {
-        return $this->schedule_type === self::TYPE_AVAILABILITY;
+        return $this->schedule_type->is(ScheduleTypes::AVAILABILITY);
     }
 
     /**
@@ -256,7 +247,7 @@ class Schedule extends Model
      */
     public function isAppointment(): bool
     {
-        return $this->schedule_type === self::TYPE_APPOINTMENT;
+        return $this->schedule_type->is(ScheduleTypes::APPOINTMENT);
     }
 
     /**
@@ -264,7 +255,7 @@ class Schedule extends Model
      */
     public function isBlocked(): bool
     {
-        return $this->schedule_type === self::TYPE_BLOCKED;
+        return $this->schedule_type->is(ScheduleTypes::BLOCKED);
     }
 
     /**
@@ -272,7 +263,7 @@ class Schedule extends Model
      */
     public function isCustom(): bool
     {
-        return $this->schedule_type === self::TYPE_CUSTOM;
+        return $this->schedule_type->is(ScheduleTypes::CUSTOM);
     }
 
     /**
@@ -280,7 +271,7 @@ class Schedule extends Model
      */
     public function preventsOverlaps(): bool
     {
-        return in_array($this->schedule_type, [self::TYPE_APPOINTMENT, self::TYPE_BLOCKED]);
+        return $this->schedule_type->preventsOverlaps();
     }
 
     /**
@@ -288,17 +279,6 @@ class Schedule extends Model
      */
     public function allowsOverlaps(): bool
     {
-        return $this->schedule_type === self::TYPE_AVAILABILITY ||
-               $this->schedule_type === self::TYPE_CUSTOM ||
-               $this->schedule_type === null; // For backward compatibility
-    }
-
-    /**
-     * Get the schedule type attribute, handling cases where column doesn't exist.
-     */
-    public function getScheduleTypeAttribute($value)
-    {
-        // If the column doesn't exist or is null, default to custom
-        return $value ?? self::TYPE_CUSTOM;
+        return $this->schedule_type->allowsOverlaps();
     }
 }

--- a/src/Services/ConflictDetectionService.php
+++ b/src/Services/ConflictDetectionService.php
@@ -4,6 +4,7 @@ namespace Zap\Services;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Zap\Enums\ScheduleTypes;
 use Zap\Models\Schedule;
 use Zap\Models\SchedulePeriod;
 
@@ -50,8 +51,8 @@ class ConflictDetectionService
     protected function shouldCheckConflict(Schedule $schedule1, Schedule $schedule2): bool
     {
         // Availability schedules never conflict with anything (they allow overlaps)
-        if ($schedule1->schedule_type === Schedule::TYPE_AVAILABILITY ||
-            $schedule2->schedule_type === Schedule::TYPE_AVAILABILITY) {
+        if ($schedule1->schedule_type->is(ScheduleTypes::AVAILABILITY) ||
+            $schedule2->schedule_type->is(ScheduleTypes::AVAILABILITY)) {
             return false;
         }
 
@@ -61,9 +62,9 @@ class ConflictDetectionService
             return false;
         }
 
-        $appliesTo = $noOverlapConfig['applies_to'] ?? ['appointment', 'blocked'];
-        $schedule1ShouldCheck = in_array($schedule1->schedule_type, $appliesTo);
-        $schedule2ShouldCheck = in_array($schedule2->schedule_type, $appliesTo);
+        $appliesTo = $noOverlapConfig['applies_to'] ?? [ScheduleTypes::APPOINTMENT->value, ScheduleTypes::BLOCKED->value];
+        $schedule1ShouldCheck = in_array($schedule1->schedule_type->value, $appliesTo);
+        $schedule2ShouldCheck = in_array($schedule2->schedule_type->value, $appliesTo);
 
         // Both schedules must be of types that should be checked for conflicts
         return $schedule1ShouldCheck && $schedule2ShouldCheck;

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -272,7 +272,7 @@ class ValidationService
         }
 
         // Automatically add no_overlap rule for appointment and blocked schedules if enabled
-        $scheduleType = $attributes['schedule_type'] ?? \Zap\Models\Schedule::TYPE_CUSTOM;
+        $scheduleType = $attributes['schedule_type'] ?? \Zap\Enums\ScheduleTypes::CUSTOM;
         $noOverlapConfig = config('zap.default_rules.no_overlap', []);
         $shouldApplyNoOverlap = $this->shouldApplyNoOverlapRule($scheduleType, $noOverlapConfig, $rules);
 
@@ -393,7 +393,7 @@ class ValidationService
     /**
      * Determine if no_overlap rule should be applied.
      */
-    protected function shouldApplyNoOverlapRule(string $scheduleType, array $noOverlapConfig, array $providedRules): bool
+    protected function shouldApplyNoOverlapRule(\Zap\Enums\ScheduleTypes $scheduleType, array $noOverlapConfig, array $providedRules): bool
     {
         // If no_overlap rule was explicitly provided, don't auto-apply
         if (isset($providedRules['no_overlap'])) {
@@ -539,7 +539,7 @@ class ValidationService
             'is_recurring' => $attributes['is_recurring'] ?? false,
             'frequency' => $attributes['frequency'] ?? null,
             'frequency_config' => $attributes['frequency_config'] ?? null,
-            'schedule_type' => $attributes['schedule_type'] ?? \Zap\Models\Schedule::TYPE_CUSTOM,
+            'schedule_type' => $attributes['schedule_type'] ?? \Zap\Enums\ScheduleTypes::CUSTOM,
         ]);
 
         // Create temporary periods
@@ -556,7 +556,7 @@ class ValidationService
         $tempSchedule->setRelation('periods', $tempPeriods);
 
         // For custom schedules with noOverlap rule, check conflicts with all other schedules
-        if ($tempSchedule->schedule_type === \Zap\Models\Schedule::TYPE_CUSTOM) {
+        if ($tempSchedule->schedule_type->is(\Zap\Enums\ScheduleTypes::CUSTOM)) {
             $conflicts = $this->findCustomScheduleConflicts($tempSchedule);
         } else {
             // Use the conflict detection service for typed schedules

--- a/tests/Feature/ConflictDetectionTest.php
+++ b/tests/Feature/ConflictDetectionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Zap\Enums\ScheduleTypes;
 use Zap\Exceptions\ScheduleConflictException;
 use Zap\Facades\Zap;
 use Zap\Models\Schedule;
@@ -108,7 +109,7 @@ describe('Conflict Detection', function () {
             'schedulable_id' => $user->getKey(),
             'start_date' => '2025-01-01',
             'name' => 'Conflicting Meeting',
-            'schedule_type' => Schedule::TYPE_APPOINTMENT,
+            'schedule_type' => ScheduleTypes::APPOINTMENT,
         ]);
 
         // Add periods that overlap with both existing schedules


### PR DESCRIPTION
This PR create an enum class to manage schedule types.

Tests:    
132 passed (476 assertions)

Note :
For backward compatibility reasons, the ScheduleBuilder::type() parameter is left as a string.