### PR TITLE
Fix forDate scope in Schedule

### DIFF
--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -161,11 +161,8 @@ class Schedule extends Model
     {
         $checkDate = \Carbon\Carbon::parse($date);
 
-        $query->where('start_date', '<=', $checkDate)
-            ->where(function ($q) use ($checkDate) {
-                $q->whereNull('end_date')
-                    ->orWhere('end_date', '>=', $checkDate);
-            });
+        $query->where(fn($q) => $q->where('start_date', '=', $checkDate)->whereNull('end_date'))
+            ->orWhere(fn($q) => $q->where('start_date', '<=', $checkDate)->where('end_date', '>=', $checkDate));
     }
 
     /**

--- a/tests/Unit/ScheduleTest.php
+++ b/tests/Unit/ScheduleTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Zap\Builders\ScheduleBuilder;
+use Zap\Facades\Zap;
+use Zap\Models\Schedule;
+
+describe('Schedule', function () {
+    it('filters schedules correctly using forDate scope with different start and end date', function () {
+        $user = createUser();
+
+        $schedule = Zap::for($user)
+            ->from('2025-11-11')
+            ->to('2025-12-12')
+            ->addPeriod('09:00', '10:00')
+            ->save();
+
+        $savedSchedule = Schedule::forDate('2025-11-11')->first();
+
+        expect($savedSchedule)->toBeInstanceOf(Schedule::class)
+            ->and($schedule->id)->toEqual($savedSchedule->id);
+    });
+
+    it('filters schedules correctly using forDate scope with different start and end date and query outside upper bound', function () {
+        $user = createUser();
+
+        Zap::for($user)
+            ->from('2025-11-11')
+            ->to('2025-11-12')
+            ->addPeriod('09:00', '10:00')
+            ->save();
+
+        $savedSchedule = Schedule::forDate('2025-11-15')->first();
+
+        expect($savedSchedule)->toBeNull();
+    });
+
+    it('filters schedules correctly using forDate scope with different start and end date and query outside lower bound', function () {
+        $user = createUser();
+
+        Zap::for($user)
+            ->from('2025-11-11')
+            ->to('2025-11-12')
+            ->addPeriod('09:00', '10:00')
+            ->save();
+
+        $savedSchedule = Schedule::forDate('2025-05-15')->first();
+
+        expect($savedSchedule)->toBeNull();
+    });
+
+    it('filters schedules correctly using forDate scope with start date only', function () {
+        $user = createUser();
+
+        $schedule = Zap::for($user)
+            ->from('2025-11-11')
+            ->addPeriod('09:00', '10:00')
+            ->save();
+
+        $savedSchedule = Schedule::forDate('2025-11-11')->first();
+
+        expect($savedSchedule)->toBeInstanceOf(Schedule::class)
+            ->and($schedule->id)->toEqual($savedSchedule->id);
+    });
+
+    it('filters schedules correctly using forDate scope with start date only and query outside upper bound', function () {
+        $user = createUser();
+
+        Zap::for($user)
+            ->from('2025-11-11')
+            ->addPeriod('09:00', '10:00')
+            ->save();
+
+        $savedSchedule = Schedule::forDate('2025-11-12')->first();
+
+        expect($savedSchedule)->toBeNull();
+    });
+
+    it('filters schedules correctly using forDate scope with start date only and query outside lower bound', function () {
+        $user = createUser();
+
+        Zap::for($user)
+            ->from('2025-11-11')
+            ->addPeriod('09:00', '10:00')
+            ->save();
+
+        $savedSchedule = Schedule::forDate('2025-05-11')->first();
+
+        expect($savedSchedule)->toBeNull();
+    });
+});


### PR DESCRIPTION
- Fix #11
- Add test case to demonstrate the correct behaviour

If I'm not mistaken, the issue here is that an empty `end_date` means "limited to the `start_date` day", therefore the previous implementation of the scope erroneously fetched all "old" schedules.