### PR TITLE
fix: detect overlapping time periods for not custom schedules

### DIFF
--- a/src/Services/ConflictDetectionService.php
+++ b/src/Services/ConflictDetectionService.php
@@ -63,6 +63,11 @@ class ConflictDetectionService
         }
 
         $appliesTo = $noOverlapConfig['applies_to'] ?? [ScheduleTypes::APPOINTMENT->value, ScheduleTypes::BLOCKED->value];
+        // We need to convert the schedule types to strings, because the documentation allows both strings and ScheduleTypes
+        $appliesTo = array_map(
+            fn (string|ScheduleTypes $type) => $type instanceof ScheduleTypes ? $type->value : $type,
+            $appliesTo
+        );
         $schedule1ShouldCheck = in_array($schedule1->schedule_type->value, $appliesTo);
         $schedule2ShouldCheck = in_array($schedule2->schedule_type->value, $appliesTo);
 

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -396,7 +396,7 @@ class ValidationService
     protected function shouldApplyNoOverlapRule(\Zap\Enums\ScheduleTypes $scheduleType, array $noOverlapConfig, array $providedRules): bool
     {
         // If no_overlap rule was explicitly provided, don't auto-apply
-        if (isset($providedRules['no_overlap'])) {
+        if (isset($providedRules['no_overlap']['enabled']) && $providedRules['no_overlap']['enabled'] === false) {
             return false;
         }
 

--- a/tests/Feature/ConflictDetectionTest.php
+++ b/tests/Feature/ConflictDetectionTest.php
@@ -26,6 +26,28 @@ describe('Conflict Detection', function () {
         })->toThrow(ScheduleConflictException::class);
     });
 
+    it('detects overlapping time periods on same date for not custom schedule', function () {
+        $user = createUser();
+        config(['zap.default_rules.no_overlap.applies_to' => [\Zap\Enums\ScheduleTypes::APPOINTMENT]]);
+
+        // Create first schedule
+        Zap::for($user)
+            ->from('2025-01-01')
+            ->addPeriod('09:00', '11:00')
+            ->appointment()
+            ->save();
+
+        // This should conflict
+        expect(function () use ($user) {
+            Zap::for($user)
+                ->from('2025-01-01')
+                ->addPeriod('10:00', '12:00') // Overlaps with 09:00-11:00
+                ->appointment()
+                ->noOverlap()
+                ->save();
+        })->toThrow(ScheduleConflictException::class);
+    });
+
     it('allows non-overlapping periods on same date', function () {
         $user = createUser();
 


### PR DESCRIPTION
- Ensure overlapping is only allowed when the schedule has the `no_overlap.enabled = false` rule
- Convert `applies_to` values to strings for proper comparison