### PR TITLE
refactor: Use `array_column` in `ScheduleTypes::values()`

### DIFF
--- a/src/Enums/ScheduleTypes.php
+++ b/src/Enums/ScheduleTypes.php
@@ -19,9 +19,7 @@ enum ScheduleTypes: string
      */
     public static function values(): array
     {
-        return collect(self::cases())
-            ->map(fn (ScheduleTypes $type): string => $type->value)
-            ->all();
+        return array_column(self::cases(), 'value');
     }
 
     /**


### PR DESCRIPTION
This is a minor code refactor improvement in the `ScheduleTypes::values()` method.