### PR TITLE
test: Fix period too short validation test

### DIFF
--- a/tests/Feature/ImprovedValidationErrorsTest.php
+++ b/tests/Feature/ImprovedValidationErrorsTest.php
@@ -8,6 +8,7 @@ describe('Improved Validation Error Messages', function () {
     beforeEach(function () {
         config([
             'zap.validation.require_future_dates' => true,
+            'zap.default_rules.max_duration.enabled' => true,
             'zap.validation.min_period_duration' => 15,
             'zap.validation.max_period_duration' => 480,
             'zap.validation.allow_overlapping_periods' => false,


### PR DESCRIPTION
This PR fixes the `it provides clear error message for period too short` validation test by adding the necessary configuration value.

<img width="1229" height="137" alt="grafik" src="https://github.com/user-attachments/assets/2c3ef161-88f0-4a0b-b211-65ae1490cc0e" />
