### PR TITLE
feat: add `Schedule` docblock for scopes

### DIFF
--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -30,6 +30,15 @@ use Zap\Enums\ScheduleTypes;
  * @property-read \Illuminate\Database\Eloquent\Collection<int, SchedulePeriod> $periods
  * @property-read Model $schedulable
  * @property-read int $total_duration
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder active(bool $active = true)
+ * @method static \Illuminate\Database\Eloquent\Builder recurring(bool $recurring = true)
+ * @method static \Illuminate\Database\Eloquent\Builder ofType(ScheduleTypes|string $type)
+ * @method static \Illuminate\Database\Eloquent\Builder availability()
+ * @method static \Illuminate\Database\Eloquent\Builder appointments()
+ * @method static \Illuminate\Database\Eloquent\Builder blocked()
+ * @method static \Illuminate\Database\Eloquent\Builder forDate(string $date)
+ * @method static \Illuminate\Database\Eloquent\Builder forDateRange(string $startDate, string $endDate)
  */
 class Schedule extends Model
 {


### PR DESCRIPTION
This PR adds the DocBlock for the `Schedule` model scopes.

## Before
<img width="472" height="212" alt="grafik" src="https://github.com/user-attachments/assets/fe7a0721-6ff4-4004-8370-c77b5a9df1c6" />


## After
<img width="472" height="212" alt="grafik" src="https://github.com/user-attachments/assets/89a08fe4-8459-487d-82a8-0afb1a692ea8" />
