### PR TITLE
Remove loading of migrations in ZapServiceProvider

### DIFF
--- a/src/ZapServiceProvider.php
+++ b/src/ZapServiceProvider.php
@@ -32,8 +32,6 @@ class ZapServiceProvider extends ServiceProvider
     {
         require_once __DIR__.'/helpers.php';
 
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/zap.php' => config_path('zap.php'),


### PR DESCRIPTION
Migrations are already published on Installation steps.