### PR TITLE
fix: add group tag publish for migrations

### DIFF
--- a/src/ZapServiceProvider.php
+++ b/src/ZapServiceProvider.php
@@ -39,7 +39,7 @@ class ZapServiceProvider extends ServiceProvider
 
             $this->publishesMigrations([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
-            ]);
+            ], 'zap-migrations');
         }
     }
 


### PR DESCRIPTION
Following [documentation](https://www.laravel-zap.com/docs/getting-started/installation), this pull request introduces a small change to the `ZapServiceProvider` class to improve migration publishing.

* Added the `'zap-migrations'` group tag to the `publishesMigrations` call in `src/ZapServiceProvider.php`.