### PR TITLE
fix: cast diffInWeeks to int to avoid PHP 8.1+ deprecation warnings

### DIFF
--- a/src/Data/WeeklyFrequencyConfig/AbstractWeeklyFrequencyConfig.php
+++ b/src/Data/WeeklyFrequencyConfig/AbstractWeeklyFrequencyConfig.php
@@ -66,7 +66,7 @@ abstract class AbstractWeeklyFrequencyConfig extends FrequencyConfig
             return $dayMatches;
         }
 
-        return $dayMatches && $this->startsOn->diffInWeeks($date) % static::getFrequency() === 0;
+        return $dayMatches && (int) $this->startsOn->diffInWeeks($date) % static::getFrequency() === 0;
     }
 
     public function shouldCreateRecurringInstance(Schedule $schedule, CarbonInterface $date): bool
@@ -90,7 +90,7 @@ abstract class AbstractWeeklyFrequencyConfig extends FrequencyConfig
         }, $allowedDays);
 
         return in_array($date->dayOfWeek, $allowedDayNumbers) &&
-            $this->startsOn->diffInWeeks($date) % static::getFrequency() === 0;
+            (int) $this->startsOn->diffInWeeks($date) % static::getFrequency() === 0;
     }
 
     public function getNextRecurrence(CarbonInterface $current): CarbonInterface
@@ -126,7 +126,7 @@ abstract class AbstractWeeklyFrequencyConfig extends FrequencyConfig
         }, $allowedDays);
 
         // Find the next allowed day
-        while (! in_array($next->dayOfWeek, $allowedDayNumbers) || $this->startsOn->diffInWeeks($next) % static::getFrequency() !== 0) {
+        while (! in_array($next->dayOfWeek, $allowedDayNumbers) || (int) $this->startsOn->diffInWeeks($next) % static::getFrequency() !== 0) {
             $next = $next->addDay();
 
             // Prevent infinite loop

--- a/src/Data/WeeklyFrequencyConfig/EveryXWeeksFrequencyConfig.php
+++ b/src/Data/WeeklyFrequencyConfig/EveryXWeeksFrequencyConfig.php
@@ -89,7 +89,7 @@ final class EveryXWeeksFrequencyConfig extends FrequencyConfig
             return $dayMatches;
         }
 
-        return $dayMatches && $this->startsOn->diffInWeeks($date) % $this->frequencyWeeks === 0;
+        return $dayMatches && (int) $this->startsOn->diffInWeeks($date) % $this->frequencyWeeks === 0;
     }
 
     public function shouldCreateRecurringInstance(Schedule $schedule, CarbonInterface $date): bool
@@ -113,7 +113,7 @@ final class EveryXWeeksFrequencyConfig extends FrequencyConfig
         }, $allowedDays);
 
         return in_array($date->dayOfWeek, $allowedDayNumbers) &&
-            $this->startsOn->diffInWeeks($date) % $this->frequencyWeeks === 0;
+            (int) $this->startsOn->diffInWeeks($date) % $this->frequencyWeeks === 0;
     }
 
     public function getNextRecurrence(CarbonInterface $current): CarbonInterface
@@ -143,7 +143,7 @@ final class EveryXWeeksFrequencyConfig extends FrequencyConfig
             };
         }, $allowedDays);
 
-        while (! in_array($next->dayOfWeek, $allowedDayNumbers) || $this->startsOn->diffInWeeks($next) % $this->frequencyWeeks !== 0) {
+        while (! in_array($next->dayOfWeek, $allowedDayNumbers) || (int) $this->startsOn->diffInWeeks($next) % $this->frequencyWeeks !== 0) {
             $next = $next->addDay();
 
             if ($next->diffInDays($current) > $this->frequencyWeeks * 7 * 2) {

--- a/tests/Feature/Php81DeprecationWarningTest.php
+++ b/tests/Feature/Php81DeprecationWarningTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use Carbon\Carbon;
+use Zap\Data\WeeklyFrequencyConfig\BiWeeklyFrequencyConfig;
+use Zap\Data\WeeklyFrequencyConfig\EveryXWeeksFrequencyConfig;
+
+/**
+ * These tests verify that PHP 8.1+ deprecation warnings for implicit float to int
+ * conversions do not occur when using diffInWeeks() with the modulo operator.
+ *
+ * @see https://wiki.php.net/rfc/implicit-float-int-deprecate
+ * @see https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string
+ */
+describe('PHP 8.1+ Implicit Float to Int Conversion', function () {
+
+    it('should NOT emit deprecation warnings with bi-weekly frequency checks', function () {
+        $deprecationWarnings = [];
+        
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$deprecationWarnings) {
+            if ($errno === E_DEPRECATED && str_contains($errstr, 'Implicit conversion from float')) {
+                $deprecationWarnings[] = [
+                    'message' => $errstr,
+                    'file' => $errfile,
+                    'line' => $errline,
+                ];
+            }
+            // Return false to let PHP's internal error handler run as well
+            return false;
+        });
+
+        try {
+            $config = new BiWeeklyFrequencyConfig(
+                days: ['monday', 'wednesday'],
+                startsOn: Carbon::parse('2025-03-10')
+            );
+
+            // These dates produce non-integer week differences:
+            // 10 days = 1.4285714285714286 weeks
+            // 11 days = 1.5714285714285714 weeks
+            // 15 days = 2.1428571428571428 weeks
+            // 16 days = 2.2857142857142856 weeks
+            $testDates = [
+                Carbon::parse('2025-03-20'),
+                Carbon::parse('2025-03-21'),
+                Carbon::parse('2025-03-25'),
+                Carbon::parse('2025-03-26'),
+            ];
+
+            foreach ($testDates as $date) {
+                $config->shouldCreateInstance($date);
+            }
+        } finally {
+            restore_error_handler();
+        }
+
+        // If this fails, it means implicit float to int warnings are being emitted
+        expect($deprecationWarnings)->toBeEmpty(
+            'Detected implicit float to int conversion warnings. Details: ' . 
+            json_encode($deprecationWarnings, JSON_PRETTY_PRINT)
+        );
+    });
+
+    it('should NOT emit deprecation warnings with every-X-weeks frequency checks', function () {
+        $deprecationWarnings = [];
+        
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$deprecationWarnings) {
+            if ($errno === E_DEPRECATED && str_contains($errstr, 'Implicit conversion from float')) {
+                $deprecationWarnings[] = [
+                    'message' => $errstr,
+                    'file' => $errfile,
+                    'line' => $errline,
+                ];
+            }
+            return false;
+        });
+
+        try {
+            $config = new EveryXWeeksFrequencyConfig(
+                frequencyWeeks: 3,
+                days: ['tuesday', 'thursday'],
+                startsOn: Carbon::parse('2025-03-10')
+            );
+
+            $testDates = [
+                Carbon::parse('2025-03-20'), // 10 days = 1.4285714285714286 weeks
+                Carbon::parse('2025-03-27'), // 17 days = 2.4285714285714284 weeks
+                Carbon::parse('2025-04-03'), // 24 days = 3.4285714285714284 weeks
+            ];
+
+            foreach ($testDates as $date) {
+                $config->shouldCreateInstance($date);
+            }
+        } finally {
+            restore_error_handler();
+        }
+
+        expect($deprecationWarnings)->toBeEmpty(
+            'Detected implicit float to int conversion warnings. Details: ' . 
+            json_encode($deprecationWarnings, JSON_PRETTY_PRINT)
+        );
+    });
+
+    it('should not emit warnings during getNextRecurrence calculations', function () {
+        $deprecationWarnings = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecationWarnings) {
+            if ($errno === E_DEPRECATED && str_contains($errstr, 'Implicit conversion from float')) {
+                $deprecationWarnings[] = $errstr;
+            }
+            return true;
+        });
+
+        $config = new BiWeeklyFrequencyConfig(
+            days: ['monday', 'wednesday', 'friday'],
+            startsOn: Carbon::parse('2025-03-10')
+        );
+
+        $current = Carbon::parse('2025-03-20');
+        
+        $next = $config->getNextRecurrence($current);
+
+        restore_error_handler();
+
+        expect($deprecationWarnings)->toBeEmpty();
+        expect($next)->toBeInstanceOf(Carbon::class);
+    });
+});


### PR DESCRIPTION
## 👋 Introduction

First, I'd like to thank you for maintaining this excellent package! It has become my go-to solution for calendar and scheduling management Laravel apps. This work is truly appreciated!

## Summary

While building a service using the package I noticed warning messages in my app's logs. So this PR fixes implicit float-to-int conversion deprecation warnings introduced in PHP 8.1.0.

## Problem

Carbon's `diffInWeeks()` method returns a `float` value. When used with the modulo operator `%` without explicit casting, PHP 8.1+ emits deprecation warnings:

```
PHP Deprecated: Implicit conversion from float 1.4285714285714286 to int loses precision
```

## Solution

Add explicit `(int)` cast before all modulo operations on `diffInWeeks()` results.

**Before:**
```php
$this->startsOn->diffInWeeks($date) % static::getFrequency() === 0
```

**After:**
```php
(int) $this->startsOn->diffInWeeks($date) % static::getFrequency() === 0
```

## 🧪 Testing

The new test suite uses `set_error_handler()` to intercept deprecation warnings:

- **Without the fix**: Test fails with detected warnings
- **With the fix**: All tests pass, zero warnings

All existing tests continue to pass (415 tests, 1492 assertions).

## References

- **PHP RFC**: https://wiki.php.net/rfc/implicit-float-int-deprecate
- **PHP Watch**: https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string

## Impact

- **Affects**: PHP >= 8.1.0
- **Severity**: Deprecation warning (just will become error in future PHP versions)
- **Backward compatibility**: No breaking changes
