### PR TITLE
feat: rrule support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ $nextSlot = $doctor->getNextBookableSlot('2025-01-15', 60, 15);
 | **Ordinal weekday**  | `firstWednesdayOfMonth()`, `secondFridayOfMonth()`, `lastMondayOfMonth()` |
 | Every N weeks        | `everyThreeWeeks()`, … `everyFiftyTwoWeeks()` |
 | Every N months       | `everyFourMonths()`, … `everyElevenMonths()` |
+| **RRULE (RFC 5545)** | `rrule('FREQ=WEEKLY;BYDAY=MO,WE,FR')` |
 
 ### Recurrence examples
 
@@ -179,6 +180,27 @@ $schedule->everyThreeWeeks(['monday', 'friday'])->from('2025-01-06')->to('2025-1
 $schedule->everyFourWeeks(['tuesday'], '2025-01-06')->from('2025-01-13');
 $schedule->everyFourMonths(['day_of_month' => 15])->forYear(2025);
 $schedule->everyFiveMonths(['days_of_month' => [1, 15], 'start_month' => 2])->forYear(2025);
+```
+
+**RRULE (RFC 5545)**
+
+For complex or standards-based recurrence, pass any valid [RFC 5545 RRULE](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10) string. Powered by [php-rrule](https://github.com/rlanvin/php-rrule).
+
+```php
+// Every Monday, Wednesday, Friday
+$schedule->rrule('FREQ=WEEKLY;BYDAY=MO,WE,FR')->forYear(2025);
+
+// 1st and 15th of every month
+$schedule->rrule('FREQ=MONTHLY;BYMONTHDAY=1,15')->forYear(2025);
+
+// First Monday of every month
+$schedule->rrule('FREQ=MONTHLY;BYDAY=1MO')->forYear(2025);
+
+// Every 2 weeks on Tuesday (DTSTART derived from schedule start date)
+$schedule->rrule('FREQ=WEEKLY;INTERVAL=2;BYDAY=TU')->from('2025-01-07')->to('2025-12-31');
+
+// Every 3 days
+$schedule->rrule('FREQ=DAILY;INTERVAL=3')->from('2025-01-01')->to('2025-12-31');
 ```
 
 ### Date ranges

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
         }
     ],
     "require": {
-      "php": ">=8.2 <8.6",
-      "ext-intl": "*"
+        "php": ">=8.2 <8.6",
+        "ext-intl": "*",
+        "rlanvin/php-rrule": "^2.6"
     },
     "require-dev": {
         "laravel/pint": "^1.20",

--- a/src/Builders/ScheduleBuilder.php
+++ b/src/Builders/ScheduleBuilder.php
@@ -16,6 +16,7 @@ use Zap\Data\MonthlyFrequencyConfig\MonthlyFrequencyConfig;
 use Zap\Data\MonthlyFrequencyConfig\MonthlyOrdinalWeekdayFrequencyConfig;
 use Zap\Data\MonthlyFrequencyConfig\QuarterlyFrequencyConfig;
 use Zap\Data\MonthlyFrequencyConfig\SemiAnnuallyFrequencyConfig;
+use Zap\Data\RRuleFrequencyConfig;
 use Zap\Data\WeeklyFrequencyConfig\BiWeeklyFrequencyConfig;
 use Zap\Data\WeeklyFrequencyConfig\EveryXWeeksFrequencyConfig;
 use Zap\Enums\Frequency;
@@ -443,6 +444,18 @@ class ScheduleBuilder
         $this->attributes['frequency_config'] = AnnuallyFrequencyConfig::fromArray(
             $config
         );
+
+        return $this;
+    }
+
+    /**
+     * Set schedule recurrence using an RFC 5545 RRULE string.
+     */
+    public function rrule(string $rrule): self
+    {
+        $this->attributes['is_recurring'] = true;
+        $this->attributes['frequency'] = 'rrule';
+        $this->attributes['frequency_config'] = new RRuleFrequencyConfig($rrule);
 
         return $this;
     }

--- a/src/Casts/SafeFrequencyConfigCast.php
+++ b/src/Casts/SafeFrequencyConfigCast.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Zap\Data\FrequencyConfig;
 use Zap\Data\MonthlyFrequencyConfig\EveryXMonthsFrequencyConfig;
 use Zap\Data\MonthlyFrequencyConfig\MonthlyOrdinalWeekdayFrequencyConfig;
+use Zap\Data\RRuleFrequencyConfig;
 use Zap\Data\WeeklyFrequencyConfig\EveryXWeeksFrequencyConfig;
 use Zap\Models\Schedule;
 
@@ -42,6 +43,11 @@ class SafeFrequencyConfigCast implements CastsAttributes
             // Handle monthly ordinal weekday (e.g., "first Wednesday of month")
             if ($frequency === 'monthly_ordinal_weekday') {
                 return MonthlyOrdinalWeekdayFrequencyConfig::fromArray($configArray);
+            }
+
+            // Handle RRULE-based recurrence
+            if ($frequency === 'rrule') {
+                return RRuleFrequencyConfig::fromArray($configArray);
             }
 
             return $configArray;

--- a/src/Data/RRuleFrequencyConfig.php
+++ b/src/Data/RRuleFrequencyConfig.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Zap\Data;
+
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use RRule\RRule;
+use Zap\Models\Schedule;
+
+class RRuleFrequencyConfig extends FrequencyConfig
+{
+    private ?RRule $rruleInstance = null;
+
+    public function __construct(
+        public readonly string $rrule,
+        public ?string $dtstart = null,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            rrule: $data['rrule'],
+            dtstart: $data['dtstart'] ?? null,
+        );
+    }
+
+    public function setStartFromStartDate(CarbonInterface $startDate): self
+    {
+        $this->dtstart = $startDate->format('Ymd\THis');
+        $this->rruleInstance = null;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'rrule' => $this->rrule,
+            'dtstart' => $this->dtstart,
+        ]);
+    }
+
+    public function getNextRecurrence(CarbonInterface $current): CarbonInterface
+    {
+        $rrule = $this->getRRule();
+
+        foreach ($rrule as $occurrence) {
+            $date = Carbon::instance($occurrence);
+            if ($date->greaterThan($current)) {
+                return $date;
+            }
+        }
+
+        // Fallback if no future occurrence is found (finite rule exhausted)
+        return $current->copy()->addDay();
+    }
+
+    public function shouldCreateInstance(CarbonInterface $date): bool
+    {
+        return $this->getRRule()->occursAt($date->toDateString());
+    }
+
+    public function shouldCreateRecurringInstance(Schedule $schedule, CarbonInterface $date): bool
+    {
+        if ($date->lt($schedule->start_date) || ($schedule->end_date && $date->gt($schedule->end_date))) {
+            return false;
+        }
+
+        return $this->shouldCreateInstance($date);
+    }
+
+    private function getRRule(): RRule
+    {
+        if ($this->rruleInstance === null) {
+            $rruleString = $this->rrule;
+
+            // If the RRULE string doesn't contain DTSTART and we have one, prepend it
+            if ($this->dtstart && ! str_contains(strtoupper($rruleString), 'DTSTART')) {
+                $rruleString = "DTSTART:{$this->dtstart}\nRRULE:{$rruleString}";
+            }
+
+            $this->rruleInstance = new RRule($rruleString);
+        }
+
+        return $this->rruleInstance;
+    }
+}

--- a/src/Models/Builders/ScheduleBuilder.php
+++ b/src/Models/Builders/ScheduleBuilder.php
@@ -142,6 +142,14 @@ class ScheduleBuilder extends Builder
                         $ordinalWeekday->where('is_recurring', true)
                             ->where('frequency', 'monthly_ordinal_weekday')
                             ->where('frequency_config->day_of_week', $checkDate->dayOfWeek);
+                    })
+
+                    //
+                    // 7️⃣ RRULE — include all; occurrence check delegated to shouldCreateRecurringInstance
+                    //
+                    ->orWhere(function ($rrule) {
+                        $rrule->where('is_recurring', true)
+                            ->where('frequency', 'rrule');
                     });
             });
     }

--- a/tests/Feature/RRuleFrequencyTest.php
+++ b/tests/Feature/RRuleFrequencyTest.php
@@ -1,0 +1,211 @@
+<?php
+
+use Carbon\Carbon;
+use Zap\Data\RRuleFrequencyConfig;
+use Zap\Facades\Zap;
+use Zap\Models\Schedule;
+
+describe('RRULE Frequency', function () {
+
+    describe('Persistence', function () {
+
+        it('can save and retrieve an rrule schedule', function () {
+            $user = createUser();
+
+            $schedule = Zap::for($user)
+                ->named('MWF Standup')
+                ->from('2025-01-06')
+                ->to('2025-12-31')
+                ->addPeriod('09:00', '09:30')
+                ->rrule('FREQ=WEEKLY;BYDAY=MO,WE,FR')
+                ->save();
+
+            expect($schedule)->toBeInstanceOf(Schedule::class);
+            expect($schedule->is_recurring)->toBeTrue();
+            expect($schedule->frequency)->toBe('rrule');
+            expect($schedule->frequency_config)->toBeInstanceOf(RRuleFrequencyConfig::class);
+            expect($schedule->frequency_config->rrule)->toBe('FREQ=WEEKLY;BYDAY=MO,WE,FR');
+
+            $retrieved = Schedule::find($schedule->id);
+            expect($retrieved->frequency)->toBe('rrule');
+            expect($retrieved->frequency_config)->toBeInstanceOf(RRuleFrequencyConfig::class);
+            expect($retrieved->frequency_config->rrule)->toBe('FREQ=WEEKLY;BYDAY=MO,WE,FR');
+        });
+
+        it('can save and retrieve a monthly rrule', function () {
+            $user = createUser();
+
+            $schedule = Zap::for($user)
+                ->named('Monthly 1st and 15th')
+                ->from('2025-01-01')
+                ->to('2025-12-31')
+                ->addPeriod('10:00', '11:00')
+                ->rrule('FREQ=MONTHLY;BYMONTHDAY=1,15')
+                ->save();
+
+            $retrieved = Schedule::find($schedule->id);
+            expect($retrieved->frequency_config)->toBeInstanceOf(RRuleFrequencyConfig::class);
+            expect($retrieved->frequency_config->rrule)->toBe('FREQ=MONTHLY;BYMONTHDAY=1,15');
+        });
+
+    });
+
+    describe('Recurrence Logic', function () {
+
+        it('shouldCreateInstance matches weekly BYDAY pattern', function () {
+            $config = RRuleFrequencyConfig::fromArray([
+                'rrule' => 'FREQ=WEEKLY;BYDAY=MO,WE,FR',
+                'dtstart' => '20250101T000000',
+            ]);
+
+            // Monday
+            expect($config->shouldCreateInstance(Carbon::parse('2025-01-06')))->toBeTrue();
+            // Tuesday
+            expect($config->shouldCreateInstance(Carbon::parse('2025-01-07')))->toBeFalse();
+            // Wednesday
+            expect($config->shouldCreateInstance(Carbon::parse('2025-01-08')))->toBeTrue();
+            // Thursday
+            expect($config->shouldCreateInstance(Carbon::parse('2025-01-09')))->toBeFalse();
+            // Friday
+            expect($config->shouldCreateInstance(Carbon::parse('2025-01-10')))->toBeTrue();
+        });
+
+        it('shouldCreateInstance matches monthly BYMONTHDAY pattern', function () {
+            $config = RRuleFrequencyConfig::fromArray([
+                'rrule' => 'FREQ=MONTHLY;BYMONTHDAY=1,15',
+                'dtstart' => '20250101T000000',
+            ]);
+
+            expect($config->shouldCreateInstance(Carbon::parse('2025-01-01')))->toBeTrue();
+            expect($config->shouldCreateInstance(Carbon::parse('2025-01-15')))->toBeTrue();
+            expect($config->shouldCreateInstance(Carbon::parse('2025-01-10')))->toBeFalse();
+            expect($config->shouldCreateInstance(Carbon::parse('2025-02-01')))->toBeTrue();
+            expect($config->shouldCreateInstance(Carbon::parse('2025-02-15')))->toBeTrue();
+        });
+
+        it('shouldCreateRecurringInstance respects schedule date range', function () {
+            $user = createUser();
+
+            $schedule = Zap::for($user)
+                ->named('Test')
+                ->from('2025-03-01')
+                ->to('2025-06-30')
+                ->addPeriod('09:00', '10:00')
+                ->rrule('FREQ=WEEKLY;BYDAY=MO')
+                ->save();
+
+            $config = $schedule->frequency_config;
+
+            // Before schedule range
+            expect($config->shouldCreateRecurringInstance($schedule, Carbon::parse('2025-02-24')))->toBeFalse();
+            // Within range on a Monday
+            expect($config->shouldCreateRecurringInstance($schedule, Carbon::parse('2025-03-03')))->toBeTrue();
+            // Within range on a Tuesday
+            expect($config->shouldCreateRecurringInstance($schedule, Carbon::parse('2025-03-04')))->toBeFalse();
+            // After schedule range
+            expect($config->shouldCreateRecurringInstance($schedule, Carbon::parse('2025-07-07')))->toBeFalse();
+        });
+
+        it('getNextRecurrence returns the next matching date', function () {
+            $config = RRuleFrequencyConfig::fromArray([
+                'rrule' => 'FREQ=WEEKLY;BYDAY=MO,FR',
+                'dtstart' => '20250101T000000',
+            ]);
+
+            // From Monday, next should be Friday
+            $next = $config->getNextRecurrence(Carbon::parse('2025-01-06'));
+            expect($next->toDateString())->toBe('2025-01-10');
+
+            // From Friday, next should be Monday
+            $next = $config->getNextRecurrence(Carbon::parse('2025-01-10'));
+            expect($next->toDateString())->toBe('2025-01-13');
+        });
+
+    });
+
+    describe('Availability Integration', function () {
+
+        it('blocks time on rrule-matched days', function () {
+            $user = createUser();
+
+            Zap::for($user)
+                ->named('MWF Block')
+                ->from('2025-01-01')
+                ->to('2025-12-31')
+                ->addPeriod('09:00', '10:00')
+                ->rrule('FREQ=WEEKLY;BYDAY=MO,WE,FR')
+                ->save();
+
+            // Monday - blocked
+            expect($user->isAvailableAt('2025-01-06', '09:00', '10:00'))->toBeFalse();
+            // Tuesday - available
+            expect($user->isAvailableAt('2025-01-07', '09:00', '10:00'))->toBeTrue();
+            // Wednesday - blocked
+            expect($user->isAvailableAt('2025-01-08', '09:00', '10:00'))->toBeFalse();
+            // Thursday - available
+            expect($user->isAvailableAt('2025-01-09', '09:00', '10:00'))->toBeTrue();
+            // Friday - blocked
+            expect($user->isAvailableAt('2025-01-10', '09:00', '10:00'))->toBeFalse();
+        });
+
+        it('works with complex rrule patterns like first Monday of every month', function () {
+            $user = createUser();
+
+            Zap::for($user)
+                ->named('First Monday Monthly')
+                ->from('2025-01-01')
+                ->to('2025-12-31')
+                ->addPeriod('10:00', '11:00')
+                ->rrule('FREQ=MONTHLY;BYDAY=1MO')
+                ->save();
+
+            // Jan 6 2025 = 1st Monday
+            expect($user->isAvailableAt('2025-01-06', '10:00', '11:00'))->toBeFalse();
+            // Jan 13 = 2nd Monday
+            expect($user->isAvailableAt('2025-01-13', '10:00', '11:00'))->toBeTrue();
+            // Feb 3 2025 = 1st Monday
+            expect($user->isAvailableAt('2025-02-03', '10:00', '11:00'))->toBeFalse();
+        });
+
+        it('works with interval-based rrules like every 2 weeks', function () {
+            $user = createUser();
+
+            Zap::for($user)
+                ->named('Biweekly Tuesday')
+                ->from('2025-01-07')
+                ->to('2025-12-31')
+                ->addPeriod('14:00', '15:00')
+                ->rrule('FREQ=WEEKLY;INTERVAL=2;BYDAY=TU')
+                ->save();
+
+            // Jan 7 = start Tuesday (dtstart derived from schedule start_date)
+            expect($user->isAvailableAt('2025-01-07', '14:00', '15:00'))->toBeFalse();
+            // Jan 14 = 1 week later (skipped)
+            expect($user->isAvailableAt('2025-01-14', '14:00', '15:00'))->toBeTrue();
+            // Jan 21 = 2 weeks later
+            expect($user->isAvailableAt('2025-01-21', '14:00', '15:00'))->toBeFalse();
+        });
+
+    });
+
+    describe('Builder', function () {
+
+        it('sets correct attributes via rrule() method', function () {
+            $user = createUser();
+
+            $builder = Zap::for($user)
+                ->named('Test')
+                ->from('2025-01-01')
+                ->addPeriod('09:00', '10:00')
+                ->rrule('FREQ=DAILY;INTERVAL=3');
+
+            $attrs = $builder->getAttributes();
+            expect($attrs['is_recurring'])->toBeTrue();
+            expect($attrs['frequency'])->toBe('rrule');
+            expect($attrs['frequency_config'])->toBeInstanceOf(RRuleFrequencyConfig::class);
+            expect($attrs['frequency_config']->rrule)->toBe('FREQ=DAILY;INTERVAL=3');
+        });
+
+    });
+
+});


### PR DESCRIPTION
This PR adds support for raw RRULE strings.
`$schedule->rrule('FREQ=WEEKLY;INTERVAL=2;BYDAY=TU')->from('2025-01-07');`


```
// Every Monday, Wednesday, Friday
$schedule->rrule('FREQ=WEEKLY;BYDAY=MO,WE,FR')->forYear(2025);

// 1st and 15th of every month
$schedule->rrule('FREQ=MONTHLY;BYMONTHDAY=1,15')->forYear(2025);

// First Monday of every month
$schedule->rrule('FREQ=MONTHLY;BYDAY=1MO')->forYear(2025);

// Every 2 weeks on Tuesday (DTSTART derived from schedule start date)
$schedule->rrule('FREQ=WEEKLY;INTERVAL=2;BYDAY=TU')->from('2025-01-07')->to('2025-12-31');

// Every 3 days
$schedule->rrule('FREQ=DAILY;INTERVAL=3')->from('2025-01-01')->to('2025-12-31');
```